### PR TITLE
Fix missing SoapBinding and SoapBinding12 elements in WSDL export

### DIFF
--- a/src/Cogito.AspNetCore.ServiceModel.sln
+++ b/src/Cogito.AspNetCore.ServiceModel.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2008
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30309.148
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cogito.AspNetCore.ServiceModel", "Cogito.AspNetCore.ServiceModel\Cogito.AspNetCore.ServiceModel.csproj", "{721D1D80-AF90-4DBD-84FF-68DA67D74CF0}"
 EndProject

--- a/src/Cogito.AspNetCore.ServiceModel/AspNetCoreBinding.cs
+++ b/src/Cogito.AspNetCore.ServiceModel/AspNetCoreBinding.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.ServiceModel.Channels;
+using System.Text;
 using System.Xml;
 
 namespace Cogito.AspNetCore.ServiceModel
@@ -51,7 +52,7 @@ namespace Cogito.AspNetCore.ServiceModel
         /// </summary>
         public new MessageVersion MessageVersion
         {
-            get => encoding.MessageVersion;
+            get => base.MessageVersion;
             set => encoding.MessageVersion = value;
         }
 

--- a/src/Cogito.AspNetCore.ServiceModel/AspNetCoreRequestQueue.cs
+++ b/src/Cogito.AspNetCore.ServiceModel/AspNetCoreRequestQueue.cs
@@ -23,7 +23,7 @@ namespace Cogito.AspNetCore.ServiceModel
         /// </summary>
         public AspNetCoreRequestQueue()
         {
-            this.buffer = new BufferBlock<AspNetCoreRequest>();
+            buffer = new BufferBlock<AspNetCoreRequest>();
         }
 
         /// <summary>

--- a/src/Cogito.AspNetCore.ServiceModel/AspNetCoreServiceHostMiddleware.cs
+++ b/src/Cogito.AspNetCore.ServiceModel/AspNetCoreServiceHostMiddleware.cs
@@ -62,8 +62,8 @@ namespace Cogito.AspNetCore.ServiceModel
             routeId = Guid.NewGuid();
 
             // listen on multiple URIs
-            httpBaseUri = new Uri($"http://{routeId.ToString("N")}/");
-            httpsBaseUri = new Uri($"https://{routeId.ToString("N")}/");
+            httpBaseUri = new Uri($"http://{routeId:N}/");
+            httpsBaseUri = new Uri($"https://{routeId:N}/");
 
             // register for cleanup when application is stopped
             applicationLifetime.ApplicationStopping.Register(() =>
@@ -246,6 +246,14 @@ namespace Cogito.AspNetCore.ServiceModel
             // dispatch request to router, which sends to service host
             context.Items[AspNetCoreUri.UriContextItemName] = b.Uri;
             await router.RunAsync(context);
+
+            var e = new WsdlExporter();
+            e.PolicyVersion = PolicyVersion.Policy12;
+
+            foreach (var ep in host.Description.Endpoints)
+                e.ExportEndpoint(ep);
+
+            var d = e.GetGeneratedMetadata();
         }
 
     }

--- a/src/Cogito.AspNetCore.ServiceModel/Cogito.AspNetCore.ServiceModel.csproj
+++ b/src/Cogito.AspNetCore.ServiceModel/Cogito.AspNetCore.ServiceModel.csproj
@@ -12,8 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cogito.Core" Version="3.0.0" />
-    <PackageReference Include="Cogito.ServiceModel.DependencyInjection" Version="0.1.6" />
+    <PackageReference Include="Cogito.Core" Version="3.1.13" />
+    <PackageReference Include="Cogito.ServiceModel.DependencyInjection" Version="0.1.7" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />

--- a/src/Cogito.AspNetCore.ServiceModel/TextOrMtomEncoderInspector.cs
+++ b/src/Cogito.AspNetCore.ServiceModel/TextOrMtomEncoderInspector.cs
@@ -5,6 +5,7 @@ using System.ServiceModel;
 using System.ServiceModel.Channels;
 using System.ServiceModel.Description;
 using System.ServiceModel.Dispatcher;
+
 using Cogito.Collections;
 
 namespace Cogito.AspNetCore.ServiceModel
@@ -48,14 +49,14 @@ namespace Cogito.AspNetCore.ServiceModel
         {
         }
 
-        public object AfterReceiveRequest(ref Message request, System.ServiceModel.IClientChannel channel, System.ServiceModel.InstanceContext instanceContext)
+        public object AfterReceiveRequest(ref Message request, IClientChannel channel, InstanceContext instanceContext)
         {
             return request.Properties.TryGetValue(TextOrMtomEncodingBindingElement.IsIncomingMessageMtomPropertyName, out var result) ? result : null;
         }
 
         public void BeforeSendReply(ref Message reply, object correlationState)
         {
-            var isMtom = correlationState is bool && (bool)correlationState;
+            var isMtom = correlationState is bool boolean && boolean;
             reply.Properties.Add(TextOrMtomEncodingBindingElement.IsIncomingMessageMtomPropertyName, isMtom);
             if (isMtom)
             {


### PR DESCRIPTION
Original encoders called into SoapHelpers to establish SoapBinding and SoapBinding12 elements on the WSDL exporter, which it uses to extract the envelope version. Added these in through a reflective call into SoapHelper.

closes #2 